### PR TITLE
Set base path for Vite

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
+  base: '/Soonnetmall-app/',
   plugins: [vue()],
 })


### PR DESCRIPTION
## Summary
- add a `base` option in `vite.config.js`

## Testing
- `npm run gdplay` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df6d2ac38832cb1efb86dc0e34551